### PR TITLE
Replace dropdown popup with fullscreen dialog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.register("generateManifest") {
             "latestVersionCode" to android.defaultConfig.versionCode,
             "developer" to "timklge",
             "description" to "Adds a colored power or heart rate progress bar to the bottom of the screen, similar to the LEDs on Wahoo computers",
-            "releaseNotes" to "Add touchable back button"
+            "releaseNotes" to "* Replace dropdown popup with fullscreen dialog"
         )
 
         val gson = groovy.json.JsonBuilder(manifest).toPrettyString()


### PR DESCRIPTION
Replace dropdown popup with fullscreen dialog. Fixes #27 as the small dropdown popups might have given the impression that no further options are available